### PR TITLE
Making Combination Route Id Re-generation Optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cdot-wzdx-translator"
-version = "1.4.9rc1"
+version = "1.4.10rc1"
 description = "CDOT Work Zone WZDx Translators"
 authors = ["CDOT <CDOT_rtdh_prod@state.co.us>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cdot-wzdx-translator"
-version = "1.4.10rc1"
+version = "1.4.10rc2"
 description = "CDOT Work Zone WZDx Translators"
 authors = ["CDOT <CDOT_rtdh_prod@state.co.us>"]
 license = "MIT"

--- a/tests/experimental_combination/attenuator_test.py
+++ b/tests/experimental_combination/attenuator_test.py
@@ -64,6 +64,22 @@ def test_get_combined_events_valid_multiple():
     assert len(combined_events[0]["features"][0]["geometry"]["coordinates"]) > 2
 
 
+def test_get_combined_events_no_regeneration():
+    geotab_msgs = json.loads(
+        open(
+            "./tests/data/experimental_combination/geotab/geotab_msgs_double.json"
+        ).read()
+    )
+    wzdx_msgs = [json.loads(open("./tests/data/wzdx.json").read())]
+
+    with time_machine.travel(
+        datetime.datetime(2022, 7, 27, 20, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    ):
+        combined_events = attenuator.get_combined_events(geotab_msgs, wzdx_msgs, generate_missing_route_details=False)
+
+    assert len(combined_events) == 0
+
+
 def test_identify_overlapping_features_valid():
     geotab_msgs = json.loads(
         open(

--- a/tests/experimental_combination/field_devices_experimental_test.py
+++ b/tests/experimental_combination/field_devices_experimental_test.py
@@ -89,6 +89,31 @@ def test_get_combined_events_invalid():
     assert len(expected) == 0
 
 
+def test_get_combined_events_invalid_no_regeneration():
+    icone_msgs = [
+        field_devices.pre_process_field_device_feature(
+            FieldDeviceFeature.model_validate_json(
+                open(
+                    "./tests/data/experimental_combination/field_devices/field_device_hwy-159.json"
+                ).read()
+            )
+        )
+    ]
+    wzdx = [
+        json.loads(
+            open(
+                "./tests/data/experimental_combination/field_devices/wzdx_combination_hwy-159.json"
+            ).read()
+        )
+    ]
+
+    with time_machine.travel(
+        datetime.datetime(2022, 7, 27, 22, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    ):
+        expected = field_devices.get_combined_events(icone_msgs, wzdx, generate_missing_route_details=False)
+    assert len(expected) == 0
+
+
 def test_get_combined_events_invalid_different_routes():
     icone_msgs = [
         field_devices.pre_process_field_device_feature(

--- a/tests/experimental_combination/navjoy_experimental_test.py
+++ b/tests/experimental_combination/navjoy_experimental_test.py
@@ -27,3 +27,22 @@ def test_get_combined_events_valid():
         expected[0]["features"][0]["properties"]["reduced_speed_limit_kph"]
         == navjoy_msgs[0]["features"][0]["properties"]["reduced_speed_limit_kph"]
     )
+
+
+def test_get_combined_events_invalid_no_regeneration():
+    navjoy_msgs = [
+        json.loads(
+            open("./tests/data/experimental_combination/navjoy/wzdx_navjoy.json").read()
+        )
+    ]
+    wzdx = [
+        json.loads(
+            open("./tests/data/experimental_combination/navjoy/wzdx.json").read()
+        )
+    ]
+
+    with time_machine.travel(
+        datetime.datetime(2022, 7, 27, 20, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    ):
+        expected = navjoy.get_combined_events(navjoy_msgs, wzdx, generate_missing_route_details=False)
+    assert len(expected) == 0

--- a/tests/tools/cdot_geospatial_api_test.py
+++ b/tests/tools/cdot_geospatial_api_test.py
@@ -149,3 +149,21 @@ def test_make_cached_web_request_keeps_format_when_backup_format_matches():
     )
     assert api._make_web_request.call_args_list[1].args[0].endswith("f=json")
 
+
+def test_make_cached_web_request_no_retries_without_backup_url():
+    api = cdot_geospatial_api.GeospatialApi(
+        BASE_URL="https://primary.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded",
+        BASE_URL_FORMAT="json",
+    )
+    api._make_web_request = MagicMock(
+        side_effect=[RuntimeError("boom"), '{"status": "ok"}']
+    )
+
+    actual = api._make_cached_web_request(
+        "https://primary.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded/Route?routeId=070A&f=json",
+        timeout=5,
+    )
+
+    assert actual == None
+    assert api._make_web_request.call_count == 1
+    assert api._make_web_request.call_args_list[0].args[0].endswith("f=json")

--- a/tests/tools/cdot_geospatial_api_test.py
+++ b/tests/tools/cdot_geospatial_api_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from wzdx.tools import cdot_geospatial_api
@@ -98,3 +100,52 @@ def test_get_route_between_measures_compressed_allow_reversal():
         routeId, startMeasure, endMeasure, compressed=True
     )
     assert len(actual) == 81
+
+
+def test_make_cached_web_request_retries_with_backup_url_and_format():
+    api = cdot_geospatial_api.GeospatialApi(
+        BASE_URL="https://primary.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded",
+        BASE_URL_FORMAT="json",
+        BACKUP_BASE_URL="https://backup.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded",
+        BACKUP_BASE_URL_FORMAT="pjson",
+    )
+    api._make_web_request = MagicMock(
+        side_effect=[RuntimeError("boom"), '{"status": "ok"}']
+    )
+
+    actual = api._make_cached_web_request(
+        "https://primary.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded/Route?routeId=070A&f=json",
+        timeout=5,
+    )
+
+    assert actual == {"status": "ok"}
+    assert api._make_web_request.call_count == 2
+    assert api._make_web_request.call_args_list[0].args[0].endswith("f=json")
+    assert api._make_web_request.call_args_list[1].args[0].startswith(
+        "https://backup.example"
+    )
+    assert "f=pjson" in api._make_web_request.call_args_list[1].args[0]
+
+
+def test_make_cached_web_request_keeps_format_when_backup_format_matches():
+    api = cdot_geospatial_api.GeospatialApi(
+        BASE_URL="https://primary.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded",
+        BASE_URL_FORMAT="json",
+        BACKUP_BASE_URL="https://backup.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded",
+        BACKUP_BASE_URL_FORMAT="json",
+    )
+    api._make_web_request = MagicMock(
+        side_effect=[RuntimeError("boom"), '{"status": "ok"}']
+    )
+
+    api._make_cached_web_request(
+        "https://primary.example/arcgis/rest/services/LRS/Routes/MapServer/exts/LrsServerRounded/Route?routeId=070A&f=json",
+        timeout=5,
+    )
+
+    assert api._make_web_request.call_count == 2
+    assert api._make_web_request.call_args_list[1].args[0].startswith(
+        "https://backup.example"
+    )
+    assert api._make_web_request.call_args_list[1].args[0].endswith("f=json")
+

--- a/wzdx/experimental_combination/attenuator.py
+++ b/wzdx/experimental_combination/attenuator.py
@@ -145,20 +145,29 @@ def validate_dates(geotab: dict, wzdx: dict) -> bool:
     return wzdx_start_date <= geotab_date <= wzdx_end_date
 
 
-def get_combined_events(geotab_msgs: list[dict], wzdx_msgs: list[dict]) -> list[dict]:
+def get_combined_events(
+    geotab_msgs: list[dict],
+    wzdx_msgs: list[dict],
+    generate_missing_route_details: bool = True,
+) -> list[dict]:
     """Combine/integrate overlapping Geotab AVL ATMA messages into WZDx messages
 
     Args:
-        icone_standard_msgs (list[dict]): iCone RTDH standard messages
+        geotab_msgs (list[dict]): Geotab AVL ATMA messages
         wzdx_msgs (list[dict]): WZDx messages
 
     Returns:
         list[dict]: Combined WZDx messages
     """
+
     active_wzdx_msgs = wzdx_translator.filter_active_wzdx(wzdx_msgs)
 
     combined_events = []
-    for i in identify_overlapping_features(geotab_msgs, active_wzdx_msgs):
+    for i in identify_overlapping_features(
+        geotab_msgs,
+        active_wzdx_msgs,
+        generate_missing_route_details=generate_missing_route_details,
+    ):
         geotab_msg, wzdx_msg = i
         event_status = wzdx_translator.get_event_status(wzdx_msg["features"][0])
         if event_status in ["active"]:
@@ -168,7 +177,9 @@ def get_combined_events(geotab_msgs: list[dict], wzdx_msgs: list[dict]) -> list[
 
 
 def identify_overlapping_features(
-    geotab_msgs: list[dict], wzdx_msgs: list[dict]
+    geotab_msgs: list[dict],
+    wzdx_msgs: list[dict],
+    generate_missing_route_details: bool = True,
 ) -> list[tuple[dict, dict]]:
     """Identify overlapping Geotab AVL ATMA and WZDx messages
 
@@ -181,6 +192,9 @@ def identify_overlapping_features(
     """
     geotab_routes = {}
     matching_routes = []
+
+    if not geotab_msgs or not wzdx_msgs:
+        return matching_routes
 
     for geotab_msg in geotab_msgs:
         geometry = geotab_msg["avl_location"]["position"]
@@ -221,6 +235,12 @@ def identify_overlapping_features(
             )
             continue
         if not wzdx.get("route_details_start") or not wzdx.get("route_details_end"):
+            if not generate_missing_route_details:
+                logging.debug(
+                    f"Missing route_details for WZDx object: {wzdx['features'][0]['id']}"
+                )
+                continue
+
             route_details_start, route_details_end = (
                 combination.get_route_details_for_wzdx(wzdx["features"][0])
             )

--- a/wzdx/experimental_combination/field_devices.py
+++ b/wzdx/experimental_combination/field_devices.py
@@ -150,7 +150,9 @@ def get_direction(
 
 
 def get_combined_events(
-    field_device_features: list[FieldDeviceFeature], wzdx_msgs: list[dict]
+    field_device_features: list[FieldDeviceFeature],
+    wzdx_msgs: list[dict],
+    generate_missing_route_details: bool = True,
 ) -> list[dict]:
     """Combine/integrate overlapping iCone messages into WZDx messages
 
@@ -166,7 +168,11 @@ def get_combined_events(
         wzdx_msgs, ["pending", "completed_recently"]
     )
 
-    for i in identify_overlapping_features(field_device_features, filtered_wzdx_msgs):
+    for i in identify_overlapping_features(
+        field_device_features,
+        filtered_wzdx_msgs,
+        generate_missing_route_details=generate_missing_route_details,
+    ):
         icone_msg, wzdx_msg = i
         event_status = wzdx_translator.get_event_status(wzdx_msg["features"][0])
         wzdx = combine_field_device_with_wzdx(icone_msg, wzdx_msg, event_status)
@@ -313,7 +319,9 @@ def verify_recent(field_device: FieldDeviceFeature) -> bool:
 
 
 def identify_overlapping_features(
-    field_device_features: list[FieldDeviceFeature], wzdx_msgs: list[dict]
+    field_device_features: list[FieldDeviceFeature],
+    wzdx_msgs: list[dict],
+    generate_missing_route_details: bool = True,
 ) -> list[tuple[dict, dict]]:
     """Identify overlapping WZDx events and field devices
 
@@ -327,6 +335,9 @@ def identify_overlapping_features(
     field_device_routes: dict[str, list[FieldDeviceFeature]] = {}
     wzdx_event_routes: dict[str, list[dict]] = {}
     matching_routes: list[tuple[dict, dict]] = []
+
+    if not field_device_features or not wzdx_msgs:
+        return matching_routes
 
     recent_field_device_features = [
         i for i in field_device_features if verify_recent(i)
@@ -378,6 +389,12 @@ def identify_overlapping_features(
             )
             continue
         if not wzdx.get("route_details_start") and not wzdx.get("route_details_end"):
+            if not generate_missing_route_details:
+                logging.debug(
+                    f"Missing route_details for WZDx object: {wzdx['features'][0]['id']}"
+                )
+                continue
+
             route_details_start, route_details_end = (
                 combination.get_route_details_for_wzdx(wzdx["features"][0])
             )

--- a/wzdx/experimental_combination/navjoy.py
+++ b/wzdx/experimental_combination/navjoy.py
@@ -74,7 +74,9 @@ def parse_rtdh_arguments() -> tuple[str, str, str, str]:
 
 
 def get_combined_events(
-    navjoy_wzdx_msgs: list[dict], wzdx_msgs: list[dict]
+    navjoy_wzdx_msgs: list[dict],
+    wzdx_msgs: list[dict],
+    generate_missing_route_details: bool = True,
 ) -> list[dict]:
     """Combine/integrate overlapping Navjoy 568 messages into WZDx messages
 
@@ -89,7 +91,9 @@ def get_combined_events(
     active_navjoy_wzdx_msgs = wzdx_translator.filter_active_wzdx(navjoy_wzdx_msgs)
     active_wzdx_msgs = wzdx_translator.filter_active_wzdx(wzdx_msgs)
     for i in combination.identify_overlapping_features_wzdx(
-        active_navjoy_wzdx_msgs, active_wzdx_msgs
+        active_navjoy_wzdx_msgs,
+        active_wzdx_msgs,
+        generate_missing_route_details=generate_missing_route_details,
     ):
         navjoy_msg, wzdx_msg = i
         event_status = wzdx_translator.get_event_status(wzdx_msg["features"][0])

--- a/wzdx/tools/cdot_geospatial_api.py
+++ b/wzdx/tools/cdot_geospatial_api.py
@@ -18,11 +18,11 @@ class GeospatialApi:
         setCachedRequest: Callable[[str, str], None] = lambda url, response: None,
         BASE_URL: str = os.getenv(
             "CDOT_GEOSPATIAL_API_BASE_URL",
-            "https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
+            "https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
         ),
         BACKUP_BASE_URL: str = os.getenv(
             "CDOT_GEOSPATIAL_API_BACKUP_BASE_URL",
-            "https://dtdapps.codot.gov/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
+            "https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
         ),
     ):
         """Initialize the Geospatial API
@@ -30,8 +30,8 @@ class GeospatialApi:
         Args:
             getCachedRequest ((url: str) => cached_response: str, optional): Optional method to enable custom caching. This method is called with a request url to retrieve the cached result.
             setCachedRequest ((url: str, response: str) => None, optional): Optional method to enable custom caching. This method is called with a request url and response to write the cached result.
-            BASE_URL (str, optional): Optional override of GIS server base url, should end with CdotLrsAccessRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BASE_URL, then to https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/CdotLrsAccessRounded.
-            BACKUP_BASE_URL (str, optional): Optional override of GIS server backup base url, should end with CdotLrsAccessRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BACKUP_BASE_URL, then to https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded.
+            BASE_URL (str, optional): Optional override of GIS server base url, should end with CdotLrsAccessRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BASE_URL, then to https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded.
+            BACKUP_BASE_URL (str, optional): Optional override of GIS server backup base url, should end with CdotLrsAccessRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BACKUP_BASE_URL, then to https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded.
         """
         self.getCachedRequest = getCachedRequest
         self.setCachedRequest = setCachedRequest
@@ -98,7 +98,6 @@ class GeospatialApi:
         parameters.append("f=pjson")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_API}?{'&'.join(parameters)}"
-        logging.debug(url)
 
         # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/Routes?f=pjson
         # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/Route?routeId=070A&outSR=4326&f=pjson
@@ -129,6 +128,7 @@ class GeospatialApi:
         Returns:
             dict | None: Route details (Route, Measure, MMin, MMax, Distance)
         """
+
         # Get route ID and mile marker from lat/long and heading
         lat, lng = latLng
 
@@ -141,8 +141,10 @@ class GeospatialApi:
         parameters.append("f=pjson")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_AND_MEASURE_API}?{'&'.join(parameters)}"
+        logging.debug(url)
 
-        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=10000&outSR=&f=html
+        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=1000&outSR=&f=html
+        # https://dtdapps.codot.gov/server/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=1000&outSR=&f=html
         resp = self._make_cached_web_request(url)
         if not resp:
             return None
@@ -258,7 +260,6 @@ class GeospatialApi:
                 )
                 return None
 
-        print("Route Details: ", routeDetails)
         # process direction here
         if routeDetails.get("Direction", "+") == "+":
             endMeasure = startMeasure + distanceAhead
@@ -267,7 +268,6 @@ class GeospatialApi:
             endMeasure = startMeasure - distanceAhead
             endMeasure = max(endMeasure, routeDetails["MMin"])
 
-        print("End Measure: ", endMeasure)
         if mMin is not None and mMax is not None:
             # Force mMin < mMax
             if mMin > mMax:
@@ -279,8 +279,6 @@ class GeospatialApi:
             startMeasure = min(max(startMeasure, mMin), mMax)
             endMeasure = min(max(endMeasure, mMin), mMax)
 
-        print("Final Start Measure: ", startMeasure)
-        print("Final End Measure: ", endMeasure)
         return {
             "start_measure": startMeasure,
             "end_measure": endMeasure,
@@ -331,7 +329,6 @@ class GeospatialApi:
         parameters.append(f"toMeasure={endMeasure}")
         parameters.append(f"outSR={self.SR}")
         parameters.append("f=pjson")
-        print("Parameters: ", parameters)
 
         url = (
             f"{self.BASE_URL}/{self.ROUTE_BETWEEN_MEASURES_API}?{'&'.join(parameters)}"

--- a/wzdx/tools/cdot_geospatial_api.py
+++ b/wzdx/tools/cdot_geospatial_api.py
@@ -77,7 +77,7 @@ class GeospatialApi:
             list[dict | None]: List of routes
         """
         parameters = []
-        parameters.append("f=json")
+        parameters.append(f"f={self.BASE_URL_FORMAT}")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTES_API}?{'&'.join(parameters)}"
         logging.debug(
@@ -105,7 +105,7 @@ class GeospatialApi:
         parameters = []
         parameters.append(f"routeId={routeId}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=json")
+        parameters.append(f"f={self.BASE_URL_FORMAT}")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_API}?{'&'.join(parameters)}"
 
@@ -148,7 +148,7 @@ class GeospatialApi:
         parameters.append(f"tolerance={tolerance}")
         parameters.append(f"inSR={self.SR}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=json")
+        parameters.append(f"f={self.BASE_URL_FORMAT}")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_AND_MEASURE_API}?{'&'.join(parameters)}"
         logging.debug(url)
@@ -218,7 +218,7 @@ class GeospatialApi:
         parameters.append(f"routeId={routeId}")
         parameters.append(f"measure={measure}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=json")
+        parameters.append(f"f={self.BASE_URL_FORMAT}")
 
         url = f"{self.BASE_URL}/{self.GET_POINT_AT_MEASURE_API}?{'&'.join(parameters)}"
         logging.debug(url)
@@ -338,7 +338,7 @@ class GeospatialApi:
         parameters.append(f"fromMeasure={startMeasure}")
         parameters.append(f"toMeasure={endMeasure}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=json")
+        parameters.append(f"f={self.BASE_URL_FORMAT}")
 
         url = (
             f"{self.BASE_URL}/{self.ROUTE_BETWEEN_MEASURES_API}?{'&'.join(parameters)}"

--- a/wzdx/tools/cdot_geospatial_api.py
+++ b/wzdx/tools/cdot_geospatial_api.py
@@ -22,15 +22,11 @@ class GeospatialApi:
         ),
         BASE_URL_FORMAT: str = os.getenv(
             "CDOT_GEOSPATIAL_API_BASE_URL_FORMAT",
-            "json",
-        ),
-        BACKUP_BASE_URL: str = os.getenv(
-            "CDOT_GEOSPATIAL_API_BACKUP_BASE_URL",
-            "https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
-        ),
-        BACKUP_BASE_URL_FORMAT: str = os.getenv(
-            "CDOT_GEOSPATIAL_API_BACKUP_BASE_URL_FORMAT",
             "pjson",
+        ),
+        BACKUP_BASE_URL: str = os.getenv("CDOT_GEOSPATIAL_API_BACKUP_BASE_URL"),
+        BACKUP_BASE_URL_FORMAT: str = os.getenv(
+            "CDOT_GEOSPATIAL_API_BACKUP_BASE_URL_FORMAT"
         ),
     ):
         """Initialize the Geospatial API

--- a/wzdx/tools/cdot_geospatial_api.py
+++ b/wzdx/tools/cdot_geospatial_api.py
@@ -67,7 +67,7 @@ class GeospatialApi:
             list[dict | None]: List of routes
         """
         parameters = []
-        parameters.append("f=pjson")
+        parameters.append("f=json")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTES_API}?{'&'.join(parameters)}"
         logging.debug(
@@ -95,7 +95,7 @@ class GeospatialApi:
         parameters = []
         parameters.append(f"routeId={routeId}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=pjson")
+        parameters.append("f=json")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_API}?{'&'.join(parameters)}"
 
@@ -138,7 +138,7 @@ class GeospatialApi:
         parameters.append(f"tolerance={tolerance}")
         parameters.append(f"inSR={self.SR}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=pjson")
+        parameters.append("f=json")
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_AND_MEASURE_API}?{'&'.join(parameters)}"
         logging.debug(url)
@@ -208,7 +208,7 @@ class GeospatialApi:
         parameters.append(f"routeId={routeId}")
         parameters.append(f"measure={measure}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=pjson")
+        parameters.append("f=json")
 
         url = f"{self.BASE_URL}/{self.GET_POINT_AT_MEASURE_API}?{'&'.join(parameters)}"
         logging.debug(url)
@@ -328,7 +328,7 @@ class GeospatialApi:
         parameters.append(f"fromMeasure={startMeasure}")
         parameters.append(f"toMeasure={endMeasure}")
         parameters.append(f"outSR={self.SR}")
-        parameters.append("f=pjson")
+        parameters.append("f=json")
 
         url = (
             f"{self.BASE_URL}/{self.ROUTE_BETWEEN_MEASURES_API}?{'&'.join(parameters)}"

--- a/wzdx/tools/cdot_geospatial_api.py
+++ b/wzdx/tools/cdot_geospatial_api.py
@@ -30,8 +30,8 @@ class GeospatialApi:
         Args:
             getCachedRequest ((url: str) => cached_response: str, optional): Optional method to enable custom caching. This method is called with a request url to retrieve the cached result.
             setCachedRequest ((url: str, response: str) => None, optional): Optional method to enable custom caching. This method is called with a request url and response to write the cached result.
-            BASE_URL (str, optional): Optional override of GIS server base url, should end with CdotLrsAccessRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BASE_URL, then to https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded.
-            BACKUP_BASE_URL (str, optional): Optional override of GIS server backup base url, should end with CdotLrsAccessRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BACKUP_BASE_URL, then to https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded.
+            BASE_URL (str, optional): Optional override of GIS server base url, should end with LrsServerRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BASE_URL, then to https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded.
+            BACKUP_BASE_URL (str, optional): Optional override of GIS server backup base url, should end with LrsServerRounded. Defaults first to the env variable CDOT_GEOSPATIAL_API_BACKUP_BASE_URL, then to https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded.
         """
         self.getCachedRequest = getCachedRequest
         self.setCachedRequest = setCachedRequest
@@ -74,8 +74,8 @@ class GeospatialApi:
             f"Making GET request to GIS server for get_routes_list with url {url}"
         )
 
-        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/Routes?f=pjson
-        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/Route?routeId=070A&outSR=4326&f=pjson
+        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded/Routes?f=pjson
+        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded/Route?routeId=070A&outSR=4326&f=pjson
 
         resp = self._make_cached_web_request(url, source="get_routes_list")
         if not resp:
@@ -99,8 +99,8 @@ class GeospatialApi:
 
         url = f"{self.BASE_URL}/{self.GET_ROUTE_API}?{'&'.join(parameters)}"
 
-        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/Routes?f=pjson
-        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/Route?routeId=070A&outSR=4326&f=pjson
+        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded/Routes?f=pjson
+        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded/Route?routeId=070A&outSR=4326&f=pjson
 
         resp = self._make_cached_web_request(url)
         if not resp:
@@ -143,8 +143,8 @@ class GeospatialApi:
         url = f"{self.BASE_URL}/{self.GET_ROUTE_AND_MEASURE_API}?{'&'.join(parameters)}"
         logging.debug(url)
 
-        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=1000&outSR=&f=html
-        # https://dtdapps.codot.gov/server/rest/services/LRS/Routes/MapServer/exts/CdotLrsAccessRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=1000&outSR=&f=html
+        # https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=1000&outSR=&f=html
+        # https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded/MeasureAtPoint?x=-105&y=39.5&inSR=4326&tolerance=1000&outSR=&f=html
         resp = self._make_cached_web_request(url)
         if not resp:
             return None

--- a/wzdx/tools/cdot_geospatial_api.py
+++ b/wzdx/tools/cdot_geospatial_api.py
@@ -20,9 +20,17 @@ class GeospatialApi:
             "CDOT_GEOSPATIAL_API_BASE_URL",
             "https://dtdapps.codot.gov/server/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
         ),
+        BASE_URL_FORMAT: str = os.getenv(
+            "CDOT_GEOSPATIAL_API_BASE_URL_FORMAT",
+            "json",
+        ),
         BACKUP_BASE_URL: str = os.getenv(
             "CDOT_GEOSPATIAL_API_BACKUP_BASE_URL",
             "https://dtdapps.coloradodot.info/arcgis/rest/services/LRS/Routes_withDEC/MapServer/exts/LrsServerRounded",
+        ),
+        BACKUP_BASE_URL_FORMAT: str = os.getenv(
+            "CDOT_GEOSPATIAL_API_BACKUP_BASE_URL_FORMAT",
+            "pjson",
         ),
     ):
         """Initialize the Geospatial API
@@ -36,7 +44,9 @@ class GeospatialApi:
         self.getCachedRequest = getCachedRequest
         self.setCachedRequest = setCachedRequest
         self.BASE_URL = BASE_URL
+        self.BASE_URL_FORMAT = BASE_URL_FORMAT
         self.BACKUP_BASE_URL = BACKUP_BASE_URL
+        self.BACKUP_BASE_URL_FORMAT = BACKUP_BASE_URL_FORMAT
         self.ROUTE_BETWEEN_MEASURES_API = "RouteBetweenMeasures"
         self.GET_ROUTE_AND_MEASURE_API = "MeasureAtPoint"
         self.GET_POINT_AT_MEASURE_API = "PointAtMeasure"
@@ -436,6 +446,12 @@ class GeospatialApi:
                     f"Geospatial Request Failed for {source} with url: {url}. Timeout: {timeout}. Error: {e}. Retrying with backup endpoint."
                 )
                 backup_url = url.replace(self.BASE_URL, self.BACKUP_BASE_URL)
+                if (self.BASE_URL_FORMAT and self.BACKUP_BASE_URL_FORMAT
+                    and self.BASE_URL_FORMAT != self.BACKUP_BASE_URL_FORMAT
+                ):
+                    backup_url = backup_url.replace(
+                        f"f={self.BASE_URL_FORMAT}", f"f={self.BACKUP_BASE_URL_FORMAT}"
+                    )
                 return self._make_cached_web_request(
                     backup_url,
                     timeout=timeout,

--- a/wzdx/tools/combination.py
+++ b/wzdx/tools/combination.py
@@ -169,9 +169,16 @@ def get_route_details_for_wzdx(wzdx_feature):
     return route_details_start, route_details_end
 
 
-def identify_overlapping_features_wzdx(wzdx_msgs_1, wzdx_msgs_2):
+def identify_overlapping_features_wzdx(
+    wzdx_msgs_1,
+    wzdx_msgs_2,
+    generate_missing_route_details: bool = True,
+):
     wzdx_routes_1 = {}
     wzdx_routes_2 = {}
+
+    if not wzdx_msgs_1 or not wzdx_msgs_2:
+        return []
 
     # Step 1: Add route info to iCone messages
     for wzdx_1 in wzdx_msgs_1:
@@ -193,6 +200,12 @@ def identify_overlapping_features_wzdx(wzdx_msgs_1, wzdx_msgs_2):
             )
             continue
         if not wzdx_1.get("route_details_start") or not wzdx_1.get("route_details_end"):
+            if not generate_missing_route_details:
+                logging.debug(
+                    f"Missing route_details for WZDx object: {wzdx_1['features'][0]['id']}"
+                )
+                continue
+
             route_details_start, route_details_end = get_route_details_for_wzdx(
                 wzdx_1["features"][0]
             )
@@ -239,6 +252,12 @@ def identify_overlapping_features_wzdx(wzdx_msgs_1, wzdx_msgs_2):
             )
             continue
         if not wzdx_2.get("route_details_start") or not wzdx_2.get("route_details_end"):
+            if not generate_missing_route_details:
+                logging.debug(
+                    f"Missing route_details for WZDx object: {wzdx_2['features'][0]['id']}"
+                )
+                continue
+
             route_details_start, route_details_end = get_route_details_for_wzdx(
                 wzdx_2["features"][0]
             )


### PR DESCRIPTION
Previously, wzdx message combination (with other wzdx, icone, or ATMA vehicle data) always re-generated any missing WZDx route details. This can produce vast amounts of additional GIS requests when route details are missing in a number of events, which can happen during occasional service outages. This PR makes that automatic route re-generation optional (defaults to true), so that services utilizing this package can be more fault-tolerant.

This also includes a fix to the BACKUP_BASE_URL default value, which had a typo preventing backup GIS requests from successfully generating. 